### PR TITLE
Upgrade Voice SDK Android dependency.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,7 +65,7 @@
 
         <framework src="com.google.gms:google-services:4.3.4" />
         <framework src="com.google.firebase:firebase-messaging:21.0.1" />
-        <framework src="com.twilio:voice-android:5.6.1"/>
+        <framework src="com.twilio:voice-android:5.8.0"/>
 
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice" />


### PR DESCRIPTION
This avoids a build error:

```
> Task :app:mergeDebugResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugResources'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find com.getkeepsafe.relinker:relinker:1.3.1.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/com/getkeepsafe/relinker/relinker/1.3.1/relinker-1.3.1.pom
       - https://repo.maven.apache.org/maven2/com/getkeepsafe/relinker/relinker/1.3.1/relinker-1.3.1.pom
     Required by:
         project :app > com.twilio:voice-android:5.6.1

```