### PR TITLE
Android regression: call() should accept an object as second argument.

### DIFF
--- a/src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java
+++ b/src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java
@@ -332,9 +332,7 @@ public class TwilioVoicePlugin extends CordovaPlugin {
             public void run() {
                 try {
                     String accessToken = arguments.getString(0);
-                    String number = arguments.getString(1);
-                    Map<String, String> map = new HashMap();
-                    map.put("To", number);
+                    Map<String, String> map = getMap(arguments.getJSONObject(1));
                     map.put("accessToken", accessToken);
 
                     ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)


### PR DESCRIPTION
This used to work in previous versions of the plugin, and works on iOS in the current version:

```js
window.Twilio.TwilioVoiceClient.call(token, { To: phoneNumber, customerID: customer.id });
```